### PR TITLE
Sync "6.0/stage" with "master" via GitHub Actions

### DIFF
--- a/.github/workflows/sync-with-master.yml
+++ b/.github/workflows/sync-with-master.yml
@@ -1,0 +1,21 @@
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  sync:
+    strategy:
+      matrix:
+        branch:
+          - 6.0/stage
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: delphix/actions/sync-with-master@master
+        with:
+          branch-to-sync: ${{ matrix.branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Testing:

Pushed this commit on `master` and then added a follow-on commit testing that the action works. Here is the Pull Request opened by the action:
https://github.com/sdimitro/libkdumpfile/pull/1