### PR TITLE
Release deb packages as artifacts for each new tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       #     but it doesn't hurt to put it here just in case someone
       #     copies this command in a delphix appliance.
       #
-      - run: sudo apt-get install --no-remove -y ../libkdumpfile_*deb
+      - run: sudo apt-get install --no-remove -y ../libkdumpfile*deb
       #
       # Ensure the package is installed and works as expected.
       # To do so we download a kdump-compressed crash dump

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,92 @@
+on:
+  push:
+    #
+    # For push events to refs/tags matching the pattern
+    # 'release/*' - i.e. 'release/6.0.2.1', 'release/bogus'
+    #
+    tags:
+    - 'release/*'
+
+jobs:
+  #
+  # Build and release debian package on Github.
+  # Note that we require Python 3 to be installed
+  # for the Python bindings to be compiled in the
+  # package.
+  #
+  deb-build-test-release:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+      - name: Install debian utilities
+        run: sudo apt-get install -y debhelper devscripts equivs
+      - name: Build dependencies non-interactively
+        run: sudo mk-build-deps --install --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' debian/control
+      - name: Build and generate package
+        run: dpkg-buildpackage -b -us -uc
+      - name: Print generated artifacts
+        run: ls -lh ..
+      - name: Detect binary package name
+        run: |
+          path=$(ls ../libkdumpfile_*deb)
+          echo "::set-env name=DEBIAN_PACKAGE_PATH::$path"
+          echo "::set-env name=DEBIAN_PACKAGE_NAME::$(basename $path)"
+      - name: Detect debug package name
+        run: |
+          path=$(ls ../libkdumpfile-dbgsym_*ddeb)
+          echo "::set-env name=DDEBIAN_PACKAGE_PATH::$path"
+          echo "::set-env name=DDEBIAN_PACKAGE_NAME::$(basename $path)"
+      - name: Print package names
+        run: |
+          echo $DEBIAN_PACKAGE_PATH $DDEBIAN_PACKAGE_PATH
+          echo ${{ env.DEBIAN_PACKAGE_PATH }} ${{ env.DDEBIAN_PACKAGE_PATH }}
+          echo $DEBIAN_PACKAGE_NAME $DDEBIAN_PACKAGE_NAME
+          echo ${{ env.DEBIAN_PACKAGE_NAME }} ${{ env.DDEBIAN_PACKAGE_NAME }}
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload debian package
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          #
+          # Github note:
+          #   This pulls from the CREATE RELEASE step above, referencing it's
+          #   ID to get its outputs object, which include a `upload_url`. See
+          #   this blog post for more info:
+          #   https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          #
+          # For available content-types see:
+          # https://www.iana.org/assignments/media-types/media-types.xhtml
+          #
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.DEBIAN_PACKAGE_PATH }}
+          asset_name: ${{ env.DEBIAN_PACKAGE_NAME }}
+          asset_content_type: application/vnd.debian.binary-package
+      - name: Upload debian debug package
+        id: upload-release-asset-2
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          #
+          # See comment of similar code above.
+          #
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.DDEBIAN_PACKAGE_PATH }}
+          asset_name: ${{ env.DDEBIAN_PACKAGE_NAME }}
+          asset_content_type: application/vnd.debian.binary-package


### PR DESCRIPTION
## Commit 1

Create a Github release with debian artifacts on release tag creation

= What?

Whenever someone creates a release tag (or pushes the branch of
a release tag - e.g. 'release/6.0.3.1') then this workflow will
create a Github release with the generated debian packages (binary
and dbgsym) built from the source of the repo.

= Why?

1] Research the capabilities of Github Actions: This commit can be
   the prototype of something that can guide future direction of
   building/publishing packages. Maybe we want to use this more
   maybe we dont. Maybe we just want this for all our open-source
   repos.

2] Delphix devs working on older VMs that need a newer version of
   libkdumpfile don't need to clone the repo with the latest source
   and compile it from scratch. They can just wget the debian
   artifacts and install them right away.

3] People outside of Delphix that have debian-based systems and want
   to use drgn/sdb with a dependency on libkdumpfile can just go
   ahead and grab this debian file. Little improvements like these
   help a lot to the adoption of these tools.

= Caveats

1] Bare in mind that for now the build takes place specifically in
   stock Ubuntu 18.04 VMs from Github with whatever gcc and other
   package version they have in the apt repos. We are currently not
   sure if this can cause any incompatibility or other issues but
   until we do, it is worth pointing out.

2] When a release workflow succeeds, a release with all the artifacts
   are created regardless of whether the main.yml workflow with all
   the actual tests for the package succeeds or fails. We probably
   want to look into creating a dependency between the two as if the
   tests fail, we probably don't want to make a release anyway. That
   said for now this is ok as it is easy to delete a release from the
   UI manually if the tests fail.

3] If a tag already has a release for it and we push to the branch
   of that tag, this workflow will fail because a release already
   exists. This situation can probably only happen when something
   has gone already and can be easily fixed by the UI by deleting
   the old release, but it is worth pointing out.

### Testing

I manually did the following in my local box while in the repo directory:
```
$ git tag release/6.0.2.2

$ git push origin --tags
Enumerating objects: 8, done.
Counting objects: 100% (8/8), done.
Delta compression using up to 8 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (5/5), 980 bytes | 980.00 KiB/s, done.
Total 5 (delta 1), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (1/1), completed with 1 local object.
To github.com:sdimitro/libkdumpfile.git
 * [new tag]         release/6.0.2.2 -> release/6.0.2.2
```

Then the following two workflows ran successfully on github:
main.yml -> https://github.com/sdimitro/libkdumpfile/actions/runs/177467864
new workflow introduced in this commit -> https://github.com/sdimitro/libkdumpfile/actions/runs/177467859

And the release with the two new artifacts was generated here:
https://github.com/sdimitro/libkdumpfile/releases/tag/release%2F6.0.2.2

I took the two artifacts on a new VM:
```
$ wget https://github.com/sdimitro/libkdumpfile/releases/download/release%2F6.0.2.2/libkdumpfile-dbgsym_0.3.0_amd64.ddeb
...cropped...

$ wget https://github.com/sdimitro/libkdumpfile/releases/download/release%2F6.0.2.2/libkdumpfile_0.3.0_amd64.deb
...cropped...

$ dpkg -c libkdumpfile_0.3.0_amd64.deb
...cropped...
-rw-r--r-- root/root     36079 2020-07-14 19:15 ./usr/include/libkdumpfile/addrxlat.h
-rw-r--r-- root/root     31826 2020-07-14 19:15 ./usr/include/libkdumpfile/kdumpfile.h
...cropped...
-rw-r--r-- root/root    120024 2020-07-14 19:15 ./usr/lib/x86_64-linux-gnu/libkdumpfile.so.7.0.0
...cropped...

$ dpkg -c libkdumpfile-dbgsym_0.3.0_amd64.ddeb
...cropped...
-rw-r--r-- root/root     14976 2020-07-14 19:15 ./usr/lib/debug/.build-id/07/8e266fb94c53b0986b2a825bfc305cd956e95c.debug
...cropped...
-rw-r--r-- root/root     12416 2020-07-14 19:15 ./usr/lib/debug/.build-id/46/d04d6945f201aafeb55187a7a6b91059a35e31.debug
...cropped...

$ sudo apt-get install --no-remove ./libkdumpfile*deb
Reading package lists... Done
Building dependency tree
Reading state information... Done
Note, selecting 'libkdumpfile' instead of './libkdumpfile_0.3.0_amd64.deb'
Note, selecting 'libkdumpfile-dbgsym' instead of './libkdumpfile-dbgsym_0.3.0_amd64.ddeb'
The following packages will be DOWNGRADED:
  libkdumpfile libkdumpfile-dbgsym
0 upgraded, 0 newly installed, 2 downgraded, 0 to remove and 0 not upgraded.
Need to get 0 B/629 kB of archives.
After this operation, 0 B of additional disk space will be used.
Do you want to continue? [Y/n] Y
...cropped..
Setting up libkdumpfile (0.3.0) ...
Setting up libkdumpfile-dbgsym (0.3.0) ...
Processing triggers for libc-bin (2.27-3ubuntu1.2) ...
$ echo $?
0
```

## Commit 2 (minor)

While looking into the workflow debug output I realize that we don't install the debug symbols when testing the debian package (even though the comments says otherwise) so I fixed that.