### PR TITLE
DLPX-72774 Add libsnappy-dev as a runtime dependency for libkdumpfile

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,5 +17,5 @@ Build-Depends: autoconf,
 
 Package: libkdumpfile
 Architecture: any
-Depends: ${shlibs:Depends}, ${python3:Depends}
+Depends: libsnappy-dev, ${shlibs:Depends}, ${python3:Depends}
 Description: Kernel coredump file access


### PR DESCRIPTION
Projects like drgn that use pkg-config/pkgconf for detecting installed
library dependencies during the autoconf/automake step of their
compilation fail to detect libkdumpfile if libsnappy-dev is not
installed. For us this leads to drgn being compiled without support
for analyzing kdump-compressed crash dumps.

This patch essentially installs libsnappy-dev on every system where
we install the libkdumpfile package. This way when we install
libkdumpfile as a dependency when compiling drgn in linux-pkg, we
ensure that drgn correctly detects libkdumpfile and is build with
support for it.

A better solution to look into in the future which would require a
bit more research is to generate a separate libkdumpfile-dev package
(which itself has libsnappy-dev as a dependency) and list that new
package as a build-time dependency for drgn. For now though this
patch should effectively work around our issue.

### TESTING

ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4329/

Cloned a VM from the AMI image generated above:
```
delphix@ip-10-110-251-2:~$ sudo drgn
drgn 0.0.8+unknown (using Python 3.6.9, with libkdumpfile)
For help, type help(drgn).
>>> import drgn
>>> from drgn import NULL, Object, cast, container_of, execscript, reinterpret, sizeof
>>> from drgn.helpers.linux import *
>>>
```