### PR TITLE
TOOL-11949 [Backport of TOOL-11728] libkdumpfile: builds should depend on python3 instead of python3.6

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends: autoconf,
                libtool,
                pkg-config,
                python3-distutils,
-               python3.6-dev,
+               python3-dev,
                zlib1g-dev
 
 Package: libkdumpfile

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,6 @@
 	dh $@ --with python3
 
 override_dh_auto_configure:
-	dh_auto_configure -- --with-python=/usr/bin/python3.6
+	dh_auto_configure -- --with-python=/usr/bin/python3
 
 override_dh_auto_test:


### PR DESCRIPTION
Clean cherry-pick of #20 

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5831/