### PR TITLE
DLPX-94093 LTS 24.04: update libkdumpfile for Ubuntu 24.04 appliance

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,6 @@ Build-Depends: autoconf,
                libsnappy-dev,
                libtool,
                pkg-config,
-               python3-distutils,
                python3-dev,
                zlib1g-dev
 


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
We need to port the changes made on the os-upgrade branch to develop, for the 2025.4.0.0 release.
</details>

<details open>
<summary><h2> Solution </h2></summary>

- Note, this will need to be integrated simultaneously with all the other LTS changes on other repositories, after code-complete.
- This PR has all the changes made on the os-upgrade branch, cherry-picked and squashed into a single commit for integration on the develop branch.
  - DLPX-92324 libkdumpfile build fails on Ubuntu 24.04 because of deprecated python3-distutils dependency (#34)

</details>
